### PR TITLE
fix: fixed limit break upon recruitment behaviour

### DIFF
--- a/modules/unit/index.js
+++ b/modules/unit/index.js
@@ -465,7 +465,7 @@ function createUnitData(user, unitId, unitUid, options = {}) {
     exp: Number(options.exp || 0),
     skinId: Number(options.skinId || 0),
     injury: 0,
-    limitBreakLevel: Number(options.limitBreakLevel != null ? options.limitBreakLevel : Math.min(3, Math.max(0, maxStar - 3))),
+    limitBreakLevel: Number(options.limitBreakLevel != null ? options.limitBreakLevel : 0),
     locked: false,
     summonUnit: false,
     statExp: [0, 0, 0, 0, 0, 0],


### PR DESCRIPTION
Line 468

Before:
```
limitBreakLevel: Number(options.limitBreakLevel != null ? options.limitBreakLevel : Math.min(3, Math.max(0, maxStar - 3))),
```

Essentially this makes it so that ASSR/SSR starts at max limit break, SR starts at limit break 2 and R/N starts at limit break 1.

After:
```
limitBreakLevel: Number(options.limitBreakLevel != null ? options.limitBreakLevel : 0),
```

Setting this to be 0 to exhibit normal gameplay behaviour.