### PR TITLE
fix: resolve syntax error in initial unit loyalty

### DIFF
--- a/modules/unit/index.js
+++ b/modules/unit/index.js
@@ -668,7 +668,7 @@ function addUnitExp(user, unitUid, amount, options = {}) {
   const next = splitUnitTotalExp(currentTotalExp + Math.max(0, Number(amount || 0)), maxLevel);
   unit.level = next.level;
   unit.exp = next.exp;
-  if (options.loyalty != null) unit.loyalty = clampInt(options.loyalty, 0, 10000);
+  if (options.loyalty != null) unit.loyalty = clampInt(options.loyalty, 0, MAX_UNIT_LOYALTY);
   unit.lastGrowthAt = new Date().toISOString();
   persistNormalizedUnit(user, unit);
   return unit;
@@ -937,8 +937,8 @@ function isStaleAwakenedMaxLevelOverride(unit, override, resolvedMaxLevel) {
 }
 
 function resolveInitialUnitLoyalty(options = {}) {
-  if (options.loyalty != null) return clampInt(options.loyalty, 0, );
-  return isEnvEnabled("CS_NEW_UNIT_MAX_LOYALTY") ?  : DEFAULT_NEW_UNIT_LOYALTY;
+  if (options.loyalty != null) return clampInt(options.loyalty, 0, MAX_UNIT_LOYALTY);
+  return isEnvEnabled("CS_NEW_UNIT_MAX_LOYALTY") ? MAX_UNIT_LOYALTY : DEFAULT_NEW_UNIT_LOYALTY;
 }
 
 function isEnvEnabled(name) {


### PR DESCRIPTION
This [commit](https://github.com/MadlyMoe/RevivalSide/commit/e9a88fa547d303227ac209aabc53aa73c2e6d3c1#diff-5891e13decd136cee773882a587c9820953145a87ebfa3746320229b9fa8a4bdR20) introduced a syntax error where the ternary had one of its operands removed.
```
return isEnvEnabled("CS_NEW_UNIT_MAX_LOYALTY") ?  : DEFAULT_NEW_UNIT_LOYALTY;`
```
This throws a syntax error. Restoring the original logic to return `MAX_UNIT_LOYALTY`.

I also found a hardcoded value that I replaced to use `MAX_UNIT_LOYALTY` instead.