### PR TITLE
Implemented Crafting Fix AND Grants Lost Ship on Default

### DIFF
--- a/modules/equipment-pipeline/index.js
+++ b/modules/equipment-pipeline/index.js
@@ -387,7 +387,7 @@ function craftStartAck(ctx, user, req) {
       writeSignedVarInt(Number(result && result.errorCode) || 0),
       writeNullableObjectOrNull(result && result.slot ? buildCraftSlotData(result.slot) : null),
       writeObjectList((result && result.costItems || []).map((item) => writeNullableObject(buildItemMiscData(item)))),
-      writeNullObject(),
+      writeNullableObject(buildResetCountData(result && result.resetCount)),
     ]),
   };
 }
@@ -674,7 +674,7 @@ function craftInstantAck(ctx, user, req) {
       writeSignedVarInt(Number((result && result.moldId) || req.moldId || 0) || 0),
       writeSignedVarInt(Number((result && result.moldCount) || req.moldCount || 1) || 1),
       writeObjectList((result && result.costItems || []).map((item) => writeNullableObject(buildItemMiscData(item)))),
-      writeNullObject(),
+      writeNullableObject(buildResetCountData(result && result.resetCount)),
       writeNullableObject(buildRewardData((result && result.reward) || createEmptyReward())),
     ]),
   };

--- a/server/listener.js
+++ b/server/listener.js
@@ -64,6 +64,7 @@ const {
   getArmyOperatorByUid,
   addUnitExp,
   addOperatorExp,
+  grantUnit,
 } = require("../modules/unit");
 const { INVENTORY_TYPES, getInventoryCapacity } = require("../modules/inventory-capacity");
 const {
@@ -388,6 +389,7 @@ const PAYBACK_MISSION_TABS = Object.freeze(resolvePaybackMissionTabs());
 const SIMULATION_MISSION_TABS = [6, 7, 8];
 const FAST_LOBBY_MISSION_TABS = uniqueMissionTabs([1, 2, 3, ...SIMULATION_MISSION_TABS, ...GUIDE_MISSION_TABS]);
 const POST_TUTORIAL_MIN_USER_LEVEL = Math.max(2, Number(process.env.CS_POST_TUTORIAL_MIN_USER_LEVEL || 2) || 2);
+const DEFAULT_STARTER_SHIP_ID = 21001; // NKM_SHIP_A_COFFIN_1
 const NEW_ACCOUNT_ROSTER_MODE = resolveNewAccountRosterMode();
 const SEED_NEW_ACCOUNT_TROPHIES = process.env.CS_SEED_NEW_ACCOUNT_TROPHIES === "1";
 const USE_STEAM_TOKEN_AS_ACCESS_TOKEN = process.env.CS_USE_STEAM_TOKEN_AS_ACCESS_TOKEN === "1";
@@ -10361,6 +10363,7 @@ function ensureUserDefaults(user) {
   ensureInventory(user);
   ensureLocalShopInventory(user);
   ensureArmy(user);
+  ensureDefaultShip(user);
   ensureDefaultLineup(user);
   ensureDefaultLineup(user, { deckType: 3, index: 0 });
   user.tutorial = user.tutorial && typeof user.tutorial === "object"
@@ -10377,6 +10380,20 @@ function ensureUserDefaults(user) {
   }
   if (!CLEAR_ALL_MISSIONS_STATUS) repairPostTutorialGuideMissionCompletions(user);
   return user;
+}
+
+function ensureDefaultShip(user) {
+  if (!user || getArmyShips(user).length > 0) return null;
+  const ship = grantUnit(user, DEFAULT_STARTER_SHIP_ID, {
+    level: 1,
+    exp: 0,
+    regDate: dateTimeBinaryNow(),
+    fromContract: false,
+  });
+  if (ship && process.env.CS_DEFAULT_SHIP_REPAIR_LOG !== "0") {
+    console.log(`[user-db] repaired missing default ship uid=${user.userUid || "(ephemeral)"} shipId=${DEFAULT_STARTER_SHIP_ID}`);
+  }
+  return ship;
 }
 
 function ensureLocalShopInventory(user) {


### PR DESCRIPTION
# Crafting Fix:

## Cause: 

`craftInstantAck()` in the equipment-pipeline module writes `writeNullObject()` which result in a packet misfiring as the acknowledgement is nullified. So even though the backend records it, the frontend client does not register the state change.

## Fix:

Changed the `writeNullObject()` to `writeNullableObject(buildResetCountData(result && result.resetCount)),` which creates an object that contains the result and count so the crafting acknowledgement packet does not misfire, and the client updates properly. It is kept nullable to ensure no type drift results in regressive errors.

----

# No Ship on New Game Fix:

## Cause:

`listener.js` the main server listener has a `ensureUserDefaults(user)` function that runs to ensure defaults are secure to seed every instance with a starter. Within these UserDefaults, the Ship information was `[]` meaning empty. There would be 0 ships by default. Ideally the game would supply you a ship if you do the tutorial, but if someone skips the tutorial or due to strange circumstances is able to reach the Hanger tutorial without being explicitly granted the ship it can result in the game Softlocking due to there being no ships. As such, they cannot craft new ships due to the tutorial and cannot progress the game as squads cannot deploy. This issue was raised by testers twice, so it's not a coincidence here and can legitimately happen for some unfortunate runs. 

## Fix:

`ensureDefaultShip(user)` was included inside the `ensureUserDefaults(user)`, this function does a simple check. **"If the number of ships in this account are less than 1, then grant it the default Lost ship"**, this ensures that new accounts are always guaranteed the Lost Ship in their hanger and doesn't seem to interfere with anything. Ideally this wouldn't need to fire as you go through the happy path, but for any strange cases it ensures no softlocks. 

Closes #8 
Closes #9 