### PR TITLE
Use server time for sign-in rewards on lobby join

### DIFF
--- a/packet-handlers/0204-join-lobby-req.js
+++ b/packet-handlers/0204-join-lobby-req.js
@@ -27,7 +27,7 @@ module.exports = {
       }
       const serverNow = ctx.getServerNowDate ? ctx.getServerNowDate() : new Date();
       user.lastJoinAt = serverNow.toISOString();
-      const rewardPosts = ensureLoginRewardPosts(user);
+      const rewardPosts = ensureLoginRewardPosts(user, { now: serverNow });
       const attendancePosts = ensureAttendanceRewardPosts(user, { now: serverNow, clockNow: serverNow });
       if (rewardPosts > 0 || attendancePosts > 0) {
         console.log(


### PR DESCRIPTION
The JOIN_LOBBY_REQ handler was calling ensureLoginRewardPosts without the 'now' parameter, causing it to default to the current system time instead of the simulated server time. This then caused it to send the daily sign-in reward mail on every login, because the lastSignInDate kept swapping back and forth.