### PR TITLE
Restore Android official server bridge

### DIFF
--- a/docs/android-client-host.md
+++ b/docs/android-client-host.md
@@ -21,7 +21,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File tools/build-android-resource
 powershell -NoProfile -ExecutionPolicy Bypass -File tools/package-android-offline-payload.ps1
 ```
 
-The release builder keeps Android, PC, and ExtraAsset on the source content number; it does not invent a version bump. It validates native `PatchInfo.json` MD5/size records, injects the patched Android script bundle, compiles a complete ExtraAsset cache with PC Lua tables overriding matching Android tables, adds Android-only tables and active Mod:Side overlays, and writes SHA-256 records for every hosted file. It also stages the KMP contract from the exact PC `core` and `game-data` archives.
+The release builder keeps Android, PC, and ExtraAsset on the source content number; it does not invent a content version bump. It validates native `PatchInfo.json` MD5/size records, injects the patched Android script bundle, compiles a complete ExtraAsset cache with PC Lua tables overriding matching Android tables, adds Android-only tables and active Mod:Side overlays, and writes SHA-256 records for every hosted file. It stages the KMP contract from the exact PC `core` and `game-data` archives, then adds only the Android official/RevivalSide server-switch compatibility route to the release listener.
 
 Run the hard parity gates before publishing:
 

--- a/kmp/README.md
+++ b/kmp/README.md
@@ -109,7 +109,7 @@ The debug APK bundles:
 
 - Node.js Mobile `v18.20.4` native libraries for `armeabi-v7a` and `arm64-v8a`.
 - A small JNI bridge library that starts Node in a background thread.
-- The PC release's exact listener and game-data component contents under `assets/revivalside-payload.zip`.
+- The PC release's listener and game-data component contents under `assets/revivalside-payload.zip`, with only the Android official/RevivalSide server-switch compatibility route added to the listener.
 - Android-only managed combat and .NET files under `assets/revivalside-listener`; this directory is never overlaid onto the shared listener.
 - A complete PC gameplay-table archive for the managed listener. Counter:Side's Unity bundles and ExtraAsset cache remain on the configured CDN.
 

--- a/kmp/app/build.gradle.kts
+++ b/kmp/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         applicationId = "dev.revivalside.officialprofilecapture"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3
+        versionCode = 4
         versionName = "0.4.0"
 
         ndk {

--- a/kmp/build-android-listener-assets.ps1
+++ b/kmp/build-android-listener-assets.ps1
@@ -34,6 +34,7 @@ $androidLuaCacheAssetZip = Join-Path $expectedPrefix "revivalside-android-lua-ca
 $gameplayTablesAssetZip = Join-Path $expectedPrefix "revivalside-gameplay-tables.zip"
 $gameplayTablesAssetManifest = Join-Path $expectedPrefix "revivalside-gameplay-tables-manifest.json"
 $legacyClientAssetRoot = Join-Path $expectedPrefix "revivalside-client-assets"
+$officialBridgePatcher = Join-Path $repoRoot "tools\patch-android-official-server-bridge.js"
 $scriptBundle = ""
 $androidPatchInfoPath = ""
 $hasPayload = $PayloadZip.Count -gt 0
@@ -47,6 +48,10 @@ $androidCombatRuntimes = @(
 
 if (-not $assetRootFull.StartsWith($expectedPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
   throw "Refusing to write outside Android assets: $assetRootFull"
+}
+
+if (-not (Test-Path -LiteralPath $officialBridgePatcher -PathType Leaf)) {
+  throw "Android official-server bridge patcher is missing: $officialBridgePatcher"
 }
 
 function Write-AndroidPayloadArchive([string[]]$SourcePaths, [string]$DestinationPath) {
@@ -75,7 +80,23 @@ function Write-AndroidPayloadArchive([string[]]$SourcePaths, [string]$Destinatio
             $input = $entry.Open()
             try {
               $output = $outputEntry.Open()
-              try { $input.CopyTo($output) } finally { $output.Dispose() }
+              try {
+                if ($entry.FullName.Equals("payload/app/server/listener.js", [System.StringComparison]::OrdinalIgnoreCase)) {
+                  $temporaryListener = Join-Path ([System.IO.Path]::GetTempPath()) "revivalside-android-listener-$([guid]::NewGuid().ToString('N')).js"
+                  try {
+                    $temporaryStream = [System.IO.File]::Create($temporaryListener)
+                    try { $input.CopyTo($temporaryStream) } finally { $temporaryStream.Dispose() }
+                    & node $officialBridgePatcher $temporaryListener | Write-Host
+                    if ($LASTEXITCODE -ne 0) { throw "Failed to add the Android official-server bridge to the PC release listener." }
+                    $patchedListener = [System.IO.File]::ReadAllBytes($temporaryListener)
+                    $output.Write($patchedListener, 0, $patchedListener.Length)
+                  } finally {
+                    Remove-Item -LiteralPath $temporaryListener -Force -ErrorAction SilentlyContinue
+                  }
+                } else {
+                  $input.CopyTo($output)
+                }
+              } finally { $output.Dispose() }
             } finally {
               $input.Dispose()
             }
@@ -225,7 +246,7 @@ $payloadId = "$($sourceManifest.payloadId)-android"
   archiveSize = $payloadSize
   archiveSha256 = $payloadHash
 } | ConvertTo-Json | Set-Content -LiteralPath $payloadAssetManifest -Encoding UTF8
-Write-Host "Android payload staged from the exact PC core + game-data components at $payloadAssetZip ($copiedPayloadFiles files, $payloadSize bytes)."
+Write-Host "Android payload staged from the PC core + game-data components with the official-server bridge compatibility route at $payloadAssetZip ($copiedPayloadFiles files, $payloadSize bytes)."
 
 if (Test-Path -LiteralPath $assetRootFull) {
   Remove-Item -LiteralPath $assetRootFull -Recurse -Force

--- a/kmp/check-android-listener-parity.ps1
+++ b/kmp/check-android-listener-parity.ps1
@@ -19,6 +19,13 @@ $settingsPath = Join-Path $PSScriptRoot "app\src\main\kotlin\dev\revivalside\cap
 $payloadCachePath = Join-Path $PSScriptRoot "app\src\main\kotlin\dev\revivalside\capture\android\AndroidPayloadCache.kt"
 $gradlePath = Join-Path $PSScriptRoot "app\build.gradle.kts"
 $listenerSourcePath = Join-Path $repo "server\listener.js"
+$officialBridgePatcher = Join-Path $repo "tools\patch-android-official-server-bridge.js"
+
+if (-not (Test-Path -LiteralPath $officialBridgePatcher -PathType Leaf)) {
+  throw "Android official-server bridge patcher is missing: $officialBridgePatcher"
+}
+& node $officialBridgePatcher --self-test | Write-Host
+if ($LASTEXITCODE -ne 0) { throw "Android official-server bridge patcher self-test failed." }
 
 $version = (Get-Content -Raw -LiteralPath (Join-Path $repo "package.json") | ConvertFrom-Json).version
 $gradle = Get-Content -Raw -LiteralPath $gradlePath
@@ -207,14 +214,29 @@ if ($ReleaseSnapshot) {
   if ($LASTEXITCODE -ne 0 -or $expectedBlob -notmatch '^[a-f0-9]{40}$') {
     throw "Could not resolve the immutable PC v$version listener blob."
   }
-  $listenerBytes = [System.Text.Encoding]::UTF8.GetBytes($packagedListenerSource)
-  $headerBytes = [System.Text.Encoding]::ASCII.GetBytes("blob $($listenerBytes.Length)`0")
-  $blobBytes = New-Object byte[] ($headerBytes.Length + $listenerBytes.Length)
-  [System.Buffer]::BlockCopy($headerBytes, 0, $blobBytes, 0, $headerBytes.Length)
-  [System.Buffer]::BlockCopy($listenerBytes, 0, $blobBytes, $headerBytes.Length, $listenerBytes.Length)
-  $packagedBlob = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash($blobBytes)).Replace("-", "").ToLowerInvariant()
-  if ($packagedBlob -ne $expectedBlob) {
-    throw "Android listener differs from the immutable PC v$version release listener."
+  foreach ($required in @(
+    'url.pathname === "/launcher/api/server-info-mode"',
+    'rewriteCapturedServerInfo = serverInfoMode === "revivalside";',
+    'mode must be revivalside or official'
+  )) {
+    if (-not $packagedListenerSource.Contains($required)) { throw "Packaged Android official-server bridge is missing: $required" }
+  }
+  $temporaryListener = Join-Path ([System.IO.Path]::GetTempPath()) "revivalside-android-parity-$([guid]::NewGuid().ToString('N')).js"
+  try {
+    [System.IO.File]::WriteAllText($temporaryListener, $packagedListenerSource, [System.Text.UTF8Encoding]::new($false))
+    & node $officialBridgePatcher --reverse $temporaryListener | Write-Host
+    if ($LASTEXITCODE -ne 0) { throw "Could not remove the Android official-server bridge for baseline comparison." }
+    $baselineBytes = [System.IO.File]::ReadAllBytes($temporaryListener)
+    $headerBytes = [System.Text.Encoding]::ASCII.GetBytes("blob $($baselineBytes.Length)`0")
+    $blobBytes = New-Object byte[] ($headerBytes.Length + $baselineBytes.Length)
+    [System.Buffer]::BlockCopy($headerBytes, 0, $blobBytes, 0, $headerBytes.Length)
+    [System.Buffer]::BlockCopy($baselineBytes, 0, $blobBytes, $headerBytes.Length, $baselineBytes.Length)
+    $baselineBlob = [System.BitConverter]::ToString([System.Security.Cryptography.SHA1]::Create().ComputeHash($blobBytes)).Replace("-", "").ToLowerInvariant()
+  } finally {
+    Remove-Item -LiteralPath $temporaryListener -Force -ErrorAction SilentlyContinue
+  }
+  if ($baselineBlob -ne $expectedBlob) {
+    throw "Android listener differs from PC v$version beyond the official-server bridge compatibility patch."
   }
 } else {
   foreach ($required in @(
@@ -264,5 +286,5 @@ foreach ($required in @('Os.symlink(', 'prepareDeviceCombatRuntime(target)', 'na
   }
 }
 
-$parityTarget = if ($ReleaseSnapshot) { "immutable PC release payload" } else { "live PC source" }
+$parityTarget = if ($ReleaseSnapshot) { "PC release baseline plus Android official-server bridge" } else { "live PC source" }
 Write-Host "Android listener parity OK: target=$parityTarget, PC payload v$version, payload files=$($entries.Count), source-critical files=$($sharedFiles.Count), client=$($clientContract.versionName)/$($clientContract.patchVersion), kernel TCP normal-play path."

--- a/tools/patch-android-official-server-bridge.js
+++ b/tools/patch-android-official-server-bridge.js
@@ -1,0 +1,102 @@
+const assert = require("assert");
+const fs = require("fs");
+
+const BASE_MODE = 'const REWRITE_CAPTURED_SERVER_INFO = process.env.CS_REWRITE_CAPTURED_SERVER_INFO !== "0";';
+const PATCHED_MODE = 'let rewriteCapturedServerInfo = process.env.CS_REWRITE_CAPTURED_SERVER_INFO !== "0";';
+const BASE_MIRROR = 'if (REWRITE_CAPTURED_SERVER_INFO && requestUrl.pathname.endsWith("/ServerInfo_V2.json")) {';
+const PATCHED_MIRROR = 'if (rewriteCapturedServerInfo && requestUrl.pathname.endsWith("/ServerInfo_V2.json")) {';
+const WARMUP = '  if ((req.method === "POST" || req.method === "GET") && url.pathname === "/launcher/api/warmup") {';
+const ROUTE_MARKER = 'url.pathname === "/launcher/api/server-info-mode"';
+
+function routeBlock(eol) {
+  return [
+    '  if ((req.method === "GET" || req.method === "POST") && url.pathname === "/launcher/api/server-info-mode") {',
+    '    const requestedMode = url.searchParams.get("mode");',
+    '    const serverInfoMode = requestedMode == null',
+    '      ? (rewriteCapturedServerInfo ? "revivalside" : "official")',
+    '      : String(requestedMode).trim().toLowerCase();',
+    '    if (serverInfoMode !== "revivalside" && serverInfoMode !== "official") {',
+    '      sendJsonResponse(res, 400, { ok: false, error: "mode must be revivalside or official" });',
+    '      return true;',
+    '    }',
+    '    rewriteCapturedServerInfo = serverInfoMode === "revivalside";',
+    '    console.log(`[server-info] mode=${serverInfoMode}`);',
+    '    sendJsonResponse(res, 200, { ok: true, serverInfoMode });',
+    '    return true;',
+    '  }',
+    '',
+  ].join(eol);
+}
+
+function replaceExactlyOnce(source, before, after, label) {
+  const first = source.indexOf(before);
+  assert(first >= 0, `Missing ${label} anchor`);
+  assert(source.indexOf(before, first + before.length) < 0, `Duplicate ${label} anchor`);
+  return source.slice(0, first) + after + source.slice(first + before.length);
+}
+
+function patchAndroidOfficialBridge(source) {
+  if (source.includes(ROUTE_MARKER)) {
+    assert(source.includes(PATCHED_MODE) && source.includes(PATCHED_MIRROR), "Android bridge patch is incomplete");
+    return source;
+  }
+  const eol = source.includes("\r\n") ? "\r\n" : "\n";
+  let patched = replaceExactlyOnce(source, BASE_MODE, PATCHED_MODE, "server-info mode");
+  patched = replaceExactlyOnce(patched, WARMUP, `${routeBlock(eol)}${WARMUP}`, "launcher warmup route");
+  patched = replaceExactlyOnce(patched, BASE_MIRROR, PATCHED_MIRROR, "ServerInfo rewrite");
+  return patched;
+}
+
+function removeAndroidOfficialBridge(source) {
+  if (!source.includes(ROUTE_MARKER)) {
+    assert(source.includes(BASE_MODE) && source.includes(BASE_MIRROR), "Listener is neither baseline nor Android bridge patched");
+    return source;
+  }
+  const eol = source.includes("\r\n") ? "\r\n" : "\n";
+  let baseline = replaceExactlyOnce(source, `${routeBlock(eol)}${WARMUP}`, WARMUP, "Android bridge route");
+  baseline = replaceExactlyOnce(baseline, PATCHED_MODE, BASE_MODE, "patched server-info mode");
+  baseline = replaceExactlyOnce(baseline, PATCHED_MIRROR, BASE_MIRROR, "patched ServerInfo rewrite");
+  return baseline;
+}
+
+function selfTest() {
+  const fixture = [
+    BASE_MODE,
+    "async function serveLauncherApi(req, res) {",
+    WARMUP,
+    "    return true;",
+    "  }",
+    "}",
+    "function serveMirror(requestUrl) {",
+    `  ${BASE_MIRROR}`,
+    "    return true;",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+  const patched = patchAndroidOfficialBridge(fixture);
+  assert(patched.includes(ROUTE_MARKER));
+  assert(patched.includes('rewriteCapturedServerInfo = serverInfoMode === "revivalside";'));
+  assert(patched.includes('error: "mode must be revivalside or official"'));
+  assert.strictEqual(removeAndroidOfficialBridge(patched), fixture);
+  assert.strictEqual(patchAndroidOfficialBridge(patched), patched);
+  console.log("[android-official-bridge] self-test PASS");
+}
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes("--self-test")) {
+    selfTest();
+  } else {
+    const reverse = args.includes("--reverse");
+    const paths = args.filter((value) => value !== "--reverse");
+    assert(paths.length === 1 || paths.length === 2, "Usage: node patch-android-official-server-bridge.js [--reverse] <input> [output]");
+    const input = paths[0];
+    const output = paths[1] || input;
+    const source = fs.readFileSync(input, "utf8");
+    fs.writeFileSync(output, reverse ? removeAndroidOfficialBridge(source) : patchAndroidOfficialBridge(source), "utf8");
+    console.log(`[android-official-bridge] ${reverse ? "restored baseline" : "patched"} ${output}`);
+  }
+}
+
+module.exports = { patchAndroidOfficialBridge, removeAndroidOfficialBridge };


### PR DESCRIPTION
## Summary
- restore the Android OFFICIAL/RevivalSide ServerInfo mode bridge
- keep the embedded listener byte-equivalent to the PC v0.4.0 release after reversing the Android-only route patch
- bump Android versionCode to 4 while retaining app version 0.4.0

## Verification
- bridge self-test passes
- Android release parity check passes against immutable PC v0.4.0 archives
- signed APK installed over ADB and both official ACK capture and RevivalSide mode were verified on-device
- external 12 GB payload is unchanged and does not need re-uploading